### PR TITLE
Use fopen (not open) with mmap

### DIFF
--- a/mm.h
+++ b/mm.h
@@ -10,20 +10,11 @@
  * and where there isn't POSIX I/O,
  */
 
-#ifdef BOWTIE_MM
-#define MM_FILE_CLOSE(x) if(x > 3) { close(x); }
-#define MM_READ_RET ssize_t
-#define MM_READ read
-#define MM_SEEK lseek
-#define MM_FILE int
-#define MM_FILE_INIT -1
-#else
 #define MM_FILE_CLOSE(x) if(x != NULL) { fclose(x); }
 #define MM_READ_RET size_t
 #define MM_READ(file, dest, sz) fread(dest, 1, sz, file)
 #define MM_SEEK fseek
 #define MM_FILE FILE*
 #define MM_FILE_INIT NULL
-#endif
 
 #endif /* MM_H_ */

--- a/reference.h
+++ b/reference.h
@@ -54,9 +54,8 @@ public:
 		string s3 = in + ".3.ebwt";
 		string s4 = in + ".4.ebwt";
 
-#ifdef BOWTIE_MM
-		int f3, f4;
-		if((f3 = open(s3.c_str(), O_RDONLY)) < 0) {
+		FILE *f3, *f4;
+		if((f3 = fopen(s3.c_str(), "rb")) == NULL) {
 			cerr << "Could not open reference-string index file " << s3 << " for reading." << endl;
 			cerr << "This is most likely because your index was built with an older version" << endl
 			     << "(<= 0.9.8.1) of bowtie-build.  Please re-run bowtie-build to generate a new" << endl
@@ -64,11 +63,12 @@ public:
 			loaded_ = false;
 			return;
 		}
-		if((f4 = open(s4.c_str(), O_RDONLY)) < 0) {
+		if((f4 = fopen(s4.c_str(), "rb")) == NULL) {
 			cerr << "Could not open reference-string index file " << s4 << " for reading." << endl;
 			loaded_ = false;
 			return;
 		}
+#ifdef BOWTIE_MM
 		char *mmFile = NULL;
 		if(useMm_) {
 			if(verbose_ || startVerbose) {
@@ -82,7 +82,7 @@ public:
 				throw 1;
 			}
 			mmFile = (char*)mmap((void *)0, sbuf.st_size,
-			                     PROT_READ, MAP_SHARED, f4, 0);
+			                     PROT_READ, MAP_SHARED, fileno(f4), 0);
 			if(mmFile == (void *)(-1) || mmFile == NULL) {
 				perror("mmap");
 				cerr << "Error: Could not memory-map the index file " << s4.c_str() << endl;
@@ -98,21 +98,6 @@ public:
 					logTime(cerr);
 				}
 			}
-		}
-#else
-		FILE *f3, *f4;
-		if((f3 = fopen(s3.c_str(), "rb")) == NULL) {
-			cerr << "Could not open reference-string index file " << s3 << " for reading." << endl;
-			cerr << "This is most likely because your index was built with an older version" << endl
-			     << "(<= 0.9.8.1) of bowtie-build.  Please re-run bowtie-build to generate a new" << endl
-			     << "index (or download one from the Bowtie website) and try again." << endl;
-			loaded_ = false;
-			return;
-		}
-		if((f4 = fopen(s4.c_str(), "rb"))  == NULL) {
-			cerr << "Could not open reference-string index file " << s4 << " for reading." << endl;
-			loaded_ = false;
-			return;
 		}
 #endif
 


### PR DESCRIPTION
As with jkbonfield's suggested patch to bowtie2 (merged  BenLangmead/bowtie2@8f065de5 ), use "FILE *fp" in MM code rather than "int fd" to avoid 1 byte reads (which are very slow on some versions of Lustre).