### PR TITLE
Fix build with Yosemite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ ifneq (,$(findstring Darwin,$(shell uname)))
 		CC = clang
 		EXTRA_FLAGS += -stdlib=libstdc++
 	endif
+	ifneq (,$(findstring 14,$(shell uname -r)))
+		CPP = clang++
+		CC = clang
+		EXTRA_FLAGS += -stdlib=libstdc++
+	endif
 endif
 
 LINUX = 0


### PR DESCRIPTION
Extend setting libstdc++ to OS X 10.10, since libc++ is still the default.

Fixes #14.