### PR TITLE
Added --large-index to the MANUAL files

### DIFF
--- a/MANUAL
+++ b/MANUAL
@@ -784,6 +784,11 @@ ASCII characters, e.g., `II?I`....  Integers are treated as being on
 the [Phred quality] scale unless `--solexa-quals` is also specified.
 Default: off.
 
+    --large-index
+
+Force usage of a 'large' index (those ending in '.ebwtl'), even if a
+small one is present. Default: off.
+
     Alignment
 
     -v <int>

--- a/MANUAL.markdown
+++ b/MANUAL.markdown
@@ -938,6 +938,17 @@ ASCII characters, e.g., `II?I`....  Integers are treated as being on
 the [Phred quality] scale unless [`--solexa-quals`] is also specified.
 Default: off.
 
+</td></tr><tr><td id="bowtie-options-large-index">
+
+[`--large-index`]: #bowtie-options-large-index
+
+    --large-index
+
+</td><td>
+
+Force usage of a 'large' index (those ending in '.ebwtl'), even if a
+small one is present. Default: off.
+
 </td></tr></table>
 
 #### Alignment


### PR DESCRIPTION
I noticed the --large-index option wasn't mentioned in the manual, so I added it.