### PR TITLE
Fix writing to stdout on OSX

### DIFF
--- a/filebuf.h
+++ b/filebuf.h
@@ -534,7 +534,7 @@ public:
 	}
 
 	void flush() {
-		if(!fwrite((const void *)buf_, cur_, 1, out_)) {
+		if(cur_ != fwrite((const void *)buf_, 1, cur_, out_)){
 			std::cerr << "Error while flushing and closing output" << std::endl;
 			throw 1;
 		}

--- a/hit.h
+++ b/hit.h
@@ -419,7 +419,8 @@ public:
 		if(_outs.size() > 1 && end-start > 2) {
 			sort(hs.begin() + start, hs.begin() + end);
 		}
-		char buf[4096];
+		string buf(4096, (char) 0);
+		ostringstream ss(buf, ssmode_);
 		for(size_t i = start; i < end; i++) {
 			const Hit& h = hs[i];
 			assert(h.repOk());
@@ -428,13 +429,13 @@ public:
 				diff = (refIdxToStreamIdx(h.h.first) != refIdxToStreamIdx(hs[i-1].h.first));
 				if(diff) unlock(hs[i-1].h.first);
 			}
-			ostringstream ss(ssmode_);
-			ss.rdbuf()->pubsetbuf(buf, 4096);
+
 			append(ss, h);
 			if(i == start || diff) {
 				lock(h.h.first);
 			}
-			out(h.h.first).writeChars(buf, ss.tellp());
+			out(h.h.first).writeChars(ss.str().c_str(), ss.tellp());
+			ss.seekp(0);
 		}
 		unlock(hs[end-1].h.first);
 		GUARD_LOCK(main_mutex_m);

--- a/sam.cpp
+++ b/sam.cpp
@@ -241,13 +241,12 @@ void SAMHitSink::reportSamHits(
 	assert_geq(end, start);
 	if(end-start == 0) return;
 	assert_gt(hs[start].mate, 0);
-	char buf[4096];
+	string buf(4096, (char) 0);
 	lock(0);
+	ostringstream ss(buf, ssmode_);
 	for(size_t i = start; i < end; i++) {
-		ostringstream ss(ssmode_);
-		ss.rdbuf()->pubsetbuf(buf, 4096);
 		append(ss, hs[i], mapq, xms);
-		out(0).writeChars(buf, ss.tellp());
+		out(0).writeChars(ss.str().c_str(), ss.tellp());
 	}
 	unlock(0);
 	mainlock();


### PR DESCRIPTION
The usage of `pubsetbuf` via `ss.rdbuf()->pubsetbuf(buf, 4096);` is problematic because `pubsetbuf` is implementation dependent. This PR allocates a string in lieu of a buffer and uses that for the `ostringstream.` 

I'm not certain what is the most relevant test to run for this patch.
