### PR TITLE
Fix # alignments reported for paired-end, and exiting after -u

### DIFF
--- a/aligner.h
+++ b/aligner.h
@@ -170,6 +170,8 @@ public:
 					saw_last_read = ret.second;
 					if(ret.first && (*patsrcs_)[i]->rdid() < qUpto_) {
 						(*aligners_)[i]->setQuery((*patsrcs_)[i]);
+					} else if(ret.first) {
+						saw_last_read = true;
 					}
 				}
 			}
@@ -291,6 +293,8 @@ public:
 							al = (*alignersSE_)[0];
 							seOrPe_[0] = true; // true = unpaired
 						}
+					} else if(ret.first) {
+						break;
 					}
 				}
 				first = false;
@@ -326,7 +330,7 @@ public:
 						// Get a new read
 						pair<bool, bool> ret = ps->nextReadPair();
 						saw_last_read = ret.second;
-						if(ps->rdid() < qUpto_ && ret.first) {
+						if(ret.first && ps->rdid() < qUpto_) {
 							if(ps->paired()) {
 								// Read currently in buffer is paired-end
 								(*alignersPE_)[i]->setQuery(ps);
@@ -336,6 +340,8 @@ public:
 								(*alignersSE_)[i]->setQuery(ps);
 								seOrPe_[i] = true; // true = unpaired
 							}
+						} else if(ret.first) {
+							break;
 						}
 					}
 				}

--- a/hit.h
+++ b/hit.h
@@ -285,7 +285,8 @@ public:
 	 * alignments or because of -m.
 	 */
 	void tallyAlignments(size_t threadId, size_t numAl, bool paired) {
-		ptNumAligned_[threadId] += numAl;
+		assert(!paired || (numAl % 2) == 0);
+		ptNumAligned_[threadId] += paired ? (numAl >> 1) : numAl;
 		if(paired) {
 			ptNumReportedPaired_[threadId] += numAl;
 		} else {


### PR DESCRIPTION
This is an attempt to fix two issues I found that manifest in some modes of Bowtie, including paired-end mode.

The first issue is that I noticed long running times even when `-u` was set to a low number.  I think this is because some loops over the input reads weren't breaking as soon as the `-u` limit was passed.  The changes to `aligner.h` seem to fix this.

The second is that I noticed the reported number of alignments was wrong for paired-end reads.  It seemed to double count the pairs.  The change to `hit.h` seems to fix this.