### PR TITLE
Fix clipping first letter of first read in batches after first

### DIFF
--- a/pat.cpp
+++ b/pat.cpp
@@ -1322,20 +1322,20 @@ pair<bool, int> RawPatternSource::nextBatchFromFile(
 	size_t readi)
 {
 	int c = getc_wrapper();
-	while(c >= 0 && (c == '\n' || c == '\r')) {
-		c = getc_wrapper();
-	}
 	vector<Read>& readbuf = batch_a ? pt.bufa_ : pt.bufb_;
 	// Read until we run out of input or until we've filled the buffer
 	for(; readi < pt.max_buf_ && c >= 0; readi++) {
 		readbuf[readi].readOrigBufLen = 0;
+		while(c >= 0 && (c == '\n' || c == '\r')) {
+			c = getc_wrapper();
+		}
 		while(c >= 0 && c != '\n' && c != '\r') {
 			readbuf[readi].readOrigBuf[readbuf[readi].readOrigBufLen++] = c;
 			c = getc_wrapper();
 		}
-		while(c >= 0 && (c == '\n' || c == '\r')) {
-			c = getc_wrapper();
-		}
+	}
+	while(readi > 0 && readbuf[readi-1].readOrigBufLen == 0) {
+		readi--;
 	}
 	return make_pair(c < 0, readi);
 }


### PR DESCRIPTION
Also robustifies to presence of multiple newlines between raw records.