### PR TITLE
Allow compilation w/ both c++03 and c++11

### DIFF
--- a/blockwise_sa.h
+++ b/blockwise_sa.h
@@ -74,7 +74,11 @@ class BlockwiseSA {
 			_logger(__logger)
 	{ }
 
-		virtual ~BlockwiseSA() { }
+		virtual ~BlockwiseSA()
+#if __cplusplus > 199711L
+			noexcept(false)
+#endif
+		{ }
 
 		/**
 		 * Get the next suffix; compute the next bucket if necessary.
@@ -200,7 +204,11 @@ class KarkkainenBlockwiseSA : public InorderBlockwiseSA<TStr> {
 #endif
 			{ _randomSrc.init(__seed); reset(); }
 
-		~KarkkainenBlockwiseSA() {
+		~KarkkainenBlockwiseSA()
+#if __cplusplus > 199711L
+			noexcept(false)
+#endif
+		{
 			if(_dc != NULL) delete _dc; _dc = NULL; // difference cover sample
 			if (_done != NULL) {
 				delete[] _done;


### PR DESCRIPTION
This seems to be all it takes to allow Bowtie to compile with both `-std=c++03` and `-std=c++11`.  I tested only with LLVM v9.1.0 on a Mac.