### PR TITLE
Add aarch64, ppc64le and s390x cases to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,78 @@
-language: c++
-compiler:
-        - clang
-        - gcc
+dist: xenial
+language: cpp
+matrix:
+  include:
+    # Linux (gcc4.9)
+    - os: linux
+      compiler: gcc-4.9
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - libtbb-dev
+      env:
+        - CC=gcc-4.9
+        - CXX=g++-4.9
+    # Linux (gcc8)
+    - os: linux
+      compiler: gcc-8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+            - libtbb-dev
+      env:
+        - CC=gcc-8
+        - CXX=g++-8
+    # MacOS
+    - os: osx
+      osx_image: xcode11.2
+      compiler: clang
+      env:
+        - CC=clang
+        - CXX=clang++
+        - NPROC="$(sysctl -n hw.activecpu)"
+      before_install:
+        - brew unlink python@2
+        - brew install tbb
+    # ARM 64-bit
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - POPCNT_CAPABILITY=0
+        - NO_TBB=1
+    # IBM Z (big endian)
+    - arch: s390x
+      compiler: gcc
+      env:
+        - POPCNT_CAPABILITY=0
+        - NO_TBB=1
+      # Skip make simple-test as it fails.
+      script: make -j $NPROC allall
+    # PPC64LE
+    - os: linux
+      arch: ppc64le
+      compiler: gcc
+      env:
+        - POPCNT_CAPABILITY=0
+        - NO_TBB=1
+      # Skip make simple-test as it fails.
+      script: make -j $NPROC allall
 cache: apt
-addons:
-  apt:
-    packages:
-    - libtbb-dev
-script: make allall && make simple-test
+env:
+  global:
+    - NPROC="$(nproc)"
+before_script:
+  - uname -m
+  - echo CC=${CC} CXX=${CXX} NPROC=${NPROC}
+  - $CC --version
+  - $CXX --version
+script: make -j $NPROC allall && make simple-test
 notifications:
-          slack:
-                  secure: K/SdL+S1lb+Vf3KucmiMh4Fyd9sWmosw+mSRjtAjAzXUYZ3zMp91bM6GzHVD1nonMQWDu3vY6TOApvnikSfd4ZSRhO4ijDda5zF3SN19Uly4vXRTC0C4UKloyVqOjx2uwXU4Mz+7cuO9RCb4CczL2HUG9tiLN5BjfbnHvQlZzsE6dJuo+5BoKq88SbNhlBlGIuLWAsVmpnaozNjowNBLb2+BtrK5KSN5eTyCVerZeoJ2ChexDXGf7SnGVQhgu05hfOB52ti1mzRaTRGY91jnKAibBaO/gyW2Q5/AeBy+OrL5poenM0rAJHjztUCw1lC1G4Mej73YyHn6V1NF0DHSYM9l8aBe0nAweAuB4tuRJ9gJtqR6GjXdqURI5ABBsFIkb9pNbJz59g9sTpKrrWmIqqj7a8Eld7nk1K+IjBVOvDT9x3PWjl/H1sAl+0bRT42lu+zjJV9BIn/Fwn+xC0syRazgDimkfPLbn/aAEBKeofwdk/DHb3amBtbHsEFZsAdI5Mrq/tIuCYO0i7jYxlmNTNsXA5a0gF1OExGJvPPDV2/lp/bPx/ncvcZvwjpst6BEyJURmM5MsMCeHbiuPvlVmA4R29BTMBaW/ZN5smF4E+CkV2IxPlpgh2c+YSX44ikYnG3v4H5QKxLI4W4E+TTn9/1EmdO0KMzNG8gEiNnKcTg=
+  slack:
+    secure: K/SdL+S1lb+Vf3KucmiMh4Fyd9sWmosw+mSRjtAjAzXUYZ3zMp91bM6GzHVD1nonMQWDu3vY6TOApvnikSfd4ZSRhO4ijDda5zF3SN19Uly4vXRTC0C4UKloyVqOjx2uwXU4Mz+7cuO9RCb4CczL2HUG9tiLN5BjfbnHvQlZzsE6dJuo+5BoKq88SbNhlBlGIuLWAsVmpnaozNjowNBLb2+BtrK5KSN5eTyCVerZeoJ2ChexDXGf7SnGVQhgu05hfOB52ti1mzRaTRGY91jnKAibBaO/gyW2Q5/AeBy+OrL5poenM0rAJHjztUCw1lC1G4Mej73YyHn6V1NF0DHSYM9l8aBe0nAweAuB4tuRJ9gJtqR6GjXdqURI5ABBsFIkb9pNbJz59g9sTpKrrWmIqqj7a8Eld7nk1K+IjBVOvDT9x3PWjl/H1sAl+0bRT42lu+zjJV9BIn/Fwn+xC0syRazgDimkfPLbn/aAEBKeofwdk/DHb3amBtbHsEFZsAdI5Mrq/tIuCYO0i7jYxlmNTNsXA5a0gF1OExGJvPPDV2/lp/bPx/ncvcZvwjpst6BEyJURmM5MsMCeHbiuPvlVmA4R29BTMBaW/ZN5smF4E+CkV2IxPlpgh2c+YSX44ikYnG3v4H5QKxLI4W4E+TTn9/1EmdO0KMzNG8gEiNnKcTg=

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ bindir = $(prefix)/bin
 SEQAN_DIR = ./SeqAn-1.1
 # treat SeqAn as a sysdir to suppress warnings
 SEQAN_INC = -isystem $(SEQAN_DIR)
-INC = $(if $(RELEASE_BUILD),-I$(CURDIR)/.include) $(SEQAN_INC) -I third_party
-CPP = g++
-CXX = $(CPP)
-CC = gcc
+INC = $(if $(RELEASE_BUILD),-I$(CURDIR)/.include) $(SEQAN_INC)
+CPP ?= g++
+CXX ?= $(CPP)
+CC ?= gcc
 LIBS = $(LDFLAGS) $(if $(RELEASE_BUILD),-L$(CURDIR)/.lib) -lz
 HEADERS = $(wildcard *.h)
 BOWTIE_MM = 1
@@ -162,6 +162,12 @@ VERSION = $(shell cat VERSION)
 BITS=32
 ifeq (x86_64,$(shell uname -m))
 	BITS=64
+else ifeq (aarch64,$(shell uname -m))
+	BITS=64
+else ifeq (s390x,$(shell uname -m))
+	BITS=64
+else ifeq (ppc64le,$(shell uname -m))
+	BITS=64
 endif
 # msys will always be 32 bit so look at the cpu arch instead.
 ifneq (,$(findstring AMD64,$(PROCESSOR_ARCHITEW6432)))
@@ -180,8 +186,8 @@ ifeq (32,$(BITS))
     $(error bowtie2 compilation requires a 64-bit platform )
 endif
 
-DEBUG_FLAGS = -O0 -g3 -m64
-RELEASE_FLAGS = -O3 -m64
+DEBUG_FLAGS = -O0 -g3
+RELEASE_FLAGS = -O3
 NOASSERT_FLAGS = -DNDEBUG
 FILE_FLAGS = -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 


### PR DESCRIPTION
I have a suggestion.

This PR is to add aarch64, ppc64le and s390x cases to Travis CI, updating `Makefile` to build each arch easily. It is related to https://github.com/BenLangmead/bowtie/pull/13 and https://github.com/BenLangmead/bowtie/pull/95 .
How do you think?

There are 2 commits in the PR.
First commit is to fiix following error on s390x.

```    
alphabet.cpp:293:1: error: narrowing conversion of ‘-1’ from ‘int’ to ‘char’ inside { } [-Wnarrowing]
```

This prevents to build on s390x. You can see [this Travis log on my forked repository](https://travis-ci.org/junaruga/bowtie/jobs/633488450#L183) for detail.

Here is [my forked repository's Travis CI result](https://travis-ci.org/junaruga/bowtie/builds/633522517
).

One note is right now for s390x, only `make allall` is executed because `make simple-test` fails.
You can see [this Travis log](https://travis-ci.org/junaruga/bowtie/jobs/633510831#L1372-L1373) for detail.

```
./bowtie-build  --threads 2 --quiet --sanity  .simple_tests.pl.fa .simple_tests.tmp
Bad exitlevel from bowtie-build: 139 at ./scripts/test/simple_tests.pl line 1141.
```

Dear maintainers, do you have any idea to fix this?

@mr-c do you know how you built bowtie for Debian bowtie s390x package? Have you run the `make simple-test` on s390x?
Do we need to apply one of the [Debian patche files](https://salsa.debian.org/med-team/bowtie/tree/master/debian/patches) to this repository?

Best regards,
Jun
