### PR TITLE
Fix compilation on arm64.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ POPCNT_CAPABILITY ?= 1
 ifeq (aarch64,$(shell uname -m))
 	POPCNT_CAPABILITY=0
 endif
+ifeq (arm64,$(shell uname -m))
+	POPCNT_CAPABILITY=0
+endif
 ifeq (1, $(POPCNT_CAPABILITY))
     override EXTRA_FLAGS += -DPOPCNT_CAPABILITY
 endif


### PR DESCRIPTION
On my M1 Mac, `uname -m` returns arm64 instead of aarch64, but I believe these two are equivalent.

For context, I am working on fixing this build in [nixpkgs](https://github.com/NixOS/nixpkgs) on M1 Darwin, which uses `clang` for compilation. The first issue I ran into was that `cpuid.h` on `clang` throws an error when included on an M1 machine.